### PR TITLE
For the sake of custom badges.

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -1,8 +1,5 @@
-; dump eShop music
-DUMP "00000219:/boss_bgm1" "boss_bgm1.m4a"
-
-; replace the Play Coin file with an example one containing 13 coins
-RESTORE "example_gamecoin.dat" "f000000b:/gamecoin.dat"
-
 ; replace the Mii Maker banner image with the Face Raiders banner image (assuming you dumped it already)
-RESTORE "dumps/0000021d/ExBanner/COMMON.bin" "00000217:/ExBanner/COMMON.bin"
+DUMP "000014d1:/BadgeMngFile.dat" "Badge2File.dat"
+DUMP "000014d1:/BadgeData.dat" "Badge2Data.dat"
+RESTORE "BadgeMngFile.dat" "000014d1:/BadgeMngFile.dat"
+RESTORE "BadgeData.dat" "000014d1:/BadgeData.dat"

--- a/config.txt
+++ b/config.txt
@@ -1,4 +1,3 @@
-; replace the Mii Maker banner image with the Face Raiders banner image (assuming you dumped it already)
 DUMP "000014d1:/BadgeMngFile.dat" "Badge2File.dat"
 DUMP "000014d1:/BadgeData.dat" "Badge2Data.dat"
 RESTORE "BadgeMngFile.dat" "000014d1:/BadgeMngFile.dat"

--- a/source/main.c
+++ b/source/main.c
@@ -10,7 +10,7 @@
 typedef int (*menuent_funcptr)(void);
 
 u8 *filebuffer;
-size_t bufsize = 0x800000;
+size_t bufsize = 0x1200000;
 
 int menu_dump();
 int menu_configdump();
@@ -149,4 +149,3 @@ int main()
 	gfxExit();
 	return 0;
 }
-


### PR DESCRIPTION
Custom Badges ExtData is a bit over 16MB, I think it would be really nice if your tool supported 16MB+ files as well, but not too much. I capped it at 18,874,368 bytes.
What do you think?
